### PR TITLE
Select specific revision hash in args

### DIFF
--- a/composer-lock-diff
+++ b/composer-lock-diff
@@ -14,11 +14,16 @@ print tableize('Production Changes', $prod);
 print tableize('Dev Changes', $dev);
 
 function diff($key) {
+    global $argv;
 
     $pkgs = array();
 
+    $ref = array_reduce($argv, function ($carry, $item) {
+        return preg_match('/^[a-f0-9]+$/', $item) ? $item : $carry;
+    }, 'HEAD');
+
     $lines = '';
-    exec('git show HEAD:composer.lock', $lines);
+    exec("git show $ref:composer.lock", $lines);
     $data = json_decode(implode("\n", $lines));
 
     foreach($data->$key as $pkg) {
@@ -101,4 +106,3 @@ function tabelizeLine($data, $widths) {
     }
     return '| ' . implode(' | ', $fields) . ' |';
 }
-


### PR DESCRIPTION
Treats an `$argv` entry that looks like a revision hash as an alternative to `HEAD` for the `git-show` command execution.